### PR TITLE
Add log and load commands with shell aliases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,18 +17,23 @@ The system is simple by design: commands are bash scripts, and the help system w
 ```bash
 ./bin/rautils help              # Show all available commands
 ./bin/rautils <command> --help  # Show help for a specific command
-```
-
-**Syntax validation:**
-```bash
-bash -n bin/rautils             # Validate main script syntax
-bash -n libexec/rautils-*       # Validate all command scripts
-```
-
-**Testing a new command:**
-```bash
 ./bin/rautils <command>         # Execute command locally before installation
 ```
+
+**Validation and testing (via Makefile):**
+```bash
+make validate                   # Run bash syntax checks and project structure validation
+make test                       # Same as validate (alias)
+```
+
+**Releasing:**
+```bash
+make release type=patch         # Bug fixes (0.1.0 -> 0.1.1)
+make release type=minor         # New features (0.1.0 -> 0.2.0)
+make release type=major         # Breaking changes (0.1.0 -> 1.0.0)
+```
+
+The release process runs validation, bumps VERSION, updates `homebrew/rautils.rb`, commits, tags, and pushes. GitHub Actions then creates the GitHub Release and updates the Homebrew tap (`raulanatol/homebrew-rautils`) with the correct SHA256. The `HOMEBREW_TAP_TOKEN` secret must be configured in the repo for tap updates.
 
 ## Architecture
 
@@ -48,24 +53,51 @@ Each command is a bash script following this pattern:
 - **Must be executable:** `chmod +x libexec/rautils-mycommand`
 
 ### Version Management
-The `VERSION` file contains the current version. The main script reads this and makes it available to all commands via the `RAUTILS_VERSION` environment variable.
+The `VERSION` file contains the current version (semver format). The main script reads this and makes it available to all commands via the `RAUTILS_VERSION` environment variable.
+
+### Release Pipeline
+- `scripts/validate.sh` — validates VERSION format, bash syntax of all scripts, executable permissions, git status
+- `scripts/bump-version.sh` — increments the version in the VERSION file
+- `scripts/create-release.sh` — orchestrates the full release (validate, bump, update formula, commit, tag, push)
+- `scripts/update-homebrew-formula.sh` — updates the Homebrew formula template
+- `.github/workflows/release.yml` — triggered on `v*` tags; creates GitHub Release and pushes updated formula to the Homebrew tap repo
+
+### Shell Aliases (`rautils load`)
+The `load` command generates shell functions so commands can be called as `ra::*` instead of `rautils <command>`:
+
+```bash
+# Add to .zshrc or .bashrc:
+eval "$(rautils load)"
+
+# Then use:
+ra::log::info "Deploying..."
+ra::log::success "Done"
+ra::generate-app-icons image.png
+```
+
+For each command in `libexec/`, `load` generates a base function `ra::<command>()`. If the command supports `--aliases`, it also generates sub-functions like `ra::<command>::<sub>()`.
+
+### Subcommand Aliases (`--aliases` convention)
+Commands with sublevels (like `log`) can expose them by handling a `--aliases` flag that prints one alias per line. Example from `rautils-log`:
+
+```bash
+if [[ "$1" == "--aliases" ]]; then
+    echo "info"
+    echo "success"
+    echo "error"
+    exit 0
+fi
+```
+
+This makes `rautils load` automatically generate `ra::log::info`, `ra::log::success`, and `ra::log::error`.
 
 ## Adding New Commands
 
 1. Create `libexec/rautils-mycommand` with proper shebang, description, and implementation
 2. Make it executable: `chmod +x libexec/rautils-mycommand`
-3. Validate syntax: `bash -n libexec/rautils-mycommand`
+3. Validate: `make validate`
 4. Test locally: `./bin/rautils mycommand`
 5. The command automatically appears in `rautils help` output
+6. If the command has sublevels, implement `--aliases` so `rautils load` generates `ra::mycommand::*` functions
 
-The description header is critical—it's parsed by the help system and displayed to users.
-
-## Releasing Versions
-
-Update the `VERSION` file and `homebrew/rautils.rb` with the new version, then:
-```bash
-git commit -am "Bump version to X.Y.Z"
-git tag -a vX.Y.Z -m "Release version X.Y.Z"
-git push origin main --tags
-```
-After pushing, the Homebrew tap repository needs to be updated separately.
+The description header is critical — it's parsed by the help system and displayed to users.

--- a/libexec/rautils-load
+++ b/libexec/rautils-load
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Description: Outputs shell functions for all rautils commands (eval in your shell config).
+
+set -eo pipefail
+
+usage() {
+    echo "Usage: eval \"\$(rautils load)\""
+    echo ""
+    echo "Generates shell functions to use rautils commands as ra::* functions."
+    echo ""
+    echo "Add this to your .zshrc or .bashrc:"
+    echo "  eval \"\$(rautils load)\""
+    echo ""
+    echo "Examples after loading:"
+    echo "  ra::log::info \"Deploying...\""
+    echo "  ra::log::success \"Done\""
+    echo "  ra::generate-app-icons image.png"
+}
+
+if [[ "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+# Scan all commands in libexec
+for cmd_path in "$RAUTILS_LIBEXEC"/rautils-*; do
+    [[ -x "$cmd_path" ]] || continue
+
+    cmd_name=$(basename "$cmd_path" | sed 's/^rautils-//')
+
+    # Skip help and load themselves
+    [[ "$cmd_name" == "help" || "$cmd_name" == "load" ]] && continue
+
+    # Generate base function: ra::command-name
+    echo "ra::${cmd_name}() { rautils ${cmd_name} \"\$@\"; }"
+
+    # If the command supports --aliases, generate sub-functions
+    aliases=$("$cmd_path" --aliases 2>/dev/null) || continue
+    while IFS= read -r sub; do
+        [[ -n "$sub" ]] || continue
+        echo "ra::${cmd_name}::${sub}() { rautils ${cmd_name} ${sub} \"\$@\"; }"
+    done <<< "$aliases"
+done

--- a/libexec/rautils-log
+++ b/libexec/rautils-log
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Description: Prints formatted log messages to the terminal (info, success, error).
+
+set -eo pipefail
+
+RESET="\e[0m"
+RED="\e[31m"
+GREEN="\e[32m"
+BLUE="\e[34m"
+
+usage() {
+    echo "Usage: rautils log <level> <message>"
+    echo ""
+    echo "Prints formatted log messages to the terminal."
+    echo ""
+    echo "Levels:"
+    echo "  info     Blue text"
+    echo "  success  Green text with 🤘 prefix"
+    echo "  error    Red text with ❗ prefix"
+    echo ""
+    echo "Examples:"
+    echo "  rautils log info \"Deploying to staging...\""
+    echo "  rautils log success \"Deploy complete\""
+    echo "  rautils log error \"Connection failed\""
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+fi
+
+# Output subcommand aliases for `rautils load`
+if [[ "$1" == "--aliases" ]]; then
+    echo "info"
+    echo "success"
+    echo "error"
+    exit 0
+fi
+
+if [[ $# -lt 2 ]]; then
+    usage
+    exit 1
+fi
+
+LEVEL="$1"
+shift
+MESSAGE="$*"
+
+case "$LEVEL" in
+    info)
+        printf "${BLUE}%s${RESET}\n" "$MESSAGE"
+        ;;
+    success)
+        printf "${GREEN} 🤘 %s${RESET}\n" "$MESSAGE"
+        ;;
+    error)
+        printf "${RED}❗%s${RESET}\n" "$MESSAGE"
+        ;;
+    *)
+        echo "Error: Unknown level '$LEVEL'. Use: info, success, error."
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Changes

- Add `rautils log` command for formatted terminal output with three levels: `info` (blue), `success` (green), `error` (red) — matching the `sout::*` style from dotfiles
- Add `rautils load` command that generates `ra::*` shell functions for all commands, enabling `eval "$(rautils load)"` in shell config
- Introduce `--aliases` convention: commands with sublevels (like `log`) can expose them so `load` generates sub-functions (e.g. `ra::log::info`)
- Update CLAUDE.md with documentation for shell aliases, the `--aliases` convention, release pipeline, and updated command references

## Pay attention to:

- The `--aliases` flag convention is optional per command — only implement it if the command has sublevels
- `load` skips `help` and `load` themselves when generating aliases

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
