### PR TITLE
Add github command with open-actions subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ ra::generate-app-icons logo.png
 | [`log`](docs/commands/log.md) | Prints formatted log messages (info, success, error) |
 | [`load`](docs/commands/load.md) | Outputs shell functions for `ra::*` aliases |
 | [`git`](docs/commands/git.md) | Git utilities (delete-merged, sync) |
+| [`github`](docs/commands/github.md) | GitHub utilities (open-actions) |
 | `help` | Shows all available commands |
 
 ## Development

--- a/docs/commands/github.md
+++ b/docs/commands/github.md
@@ -1,0 +1,34 @@
+# github
+
+GitHub utility commands.
+
+## Usage
+
+```bash
+rautils github <subcommand>
+```
+
+## Subcommands
+
+### `open-actions`
+
+Opens the GitHub Actions page for the current repository in the default browser. Detects the repository URL from the `origin` remote (supports both SSH and HTTPS remotes).
+
+```bash
+rautils github open-actions
+```
+
+## Examples
+
+```bash
+# Open the Actions page for the current repo
+rautils github open-actions
+```
+
+## Shell aliases
+
+After running `eval "$(rautils load)"`, you can use shorthand functions:
+
+```bash
+ra::github::open-actions
+```

--- a/libexec/rautils-github
+++ b/libexec/rautils-github
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Description: GitHub utility commands (open-actions).
+
+set -eo pipefail
+
+usage() {
+    echo "Usage: rautils github <subcommand>"
+    echo ""
+    echo "GitHub utility commands."
+    echo ""
+    echo "Subcommands:"
+    echo "  open-actions  Open the GitHub Actions page for the current repository"
+    echo ""
+    echo "Examples:"
+    echo "  rautils github open-actions"
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+fi
+
+# Output subcommand aliases for `rautils load`
+if [[ "$1" == "--aliases" ]]; then
+    echo "open-actions"
+    exit 0
+fi
+
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+SUBCOMMAND="$1"
+shift
+
+get_repo_url() {
+    local remote_url
+    remote_url=$(git remote get-url origin 2>/dev/null)
+
+    if [[ -z "$remote_url" ]]; then
+        echo "Error: No git remote 'origin' found." >&2
+        exit 1
+    fi
+
+    # Convert SSH or HTTPS URLs to base GitHub URL
+    remote_url="${remote_url%.git}"
+    if [[ "$remote_url" == git@* ]]; then
+        # git@github.com:user/repo -> https://github.com/user/repo
+        remote_url="${remote_url/git@github.com:/https://github.com/}"
+    fi
+
+    echo "$remote_url"
+}
+
+case "$SUBCOMMAND" in
+    open-actions)
+        REPO_URL=$(get_repo_url)
+        open "${REPO_URL}/actions"
+        ;;
+    *)
+        echo "Error: Unknown subcommand '$SUBCOMMAND'."
+        echo ""
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Changes

- Add new `github` grouped command with `open-actions` subcommand
- `open-actions` detects the repo URL from the `origin` remote (SSH and HTTPS), and opens the GitHub Actions page in the default browser
- Add command documentation at `docs/commands/github.md`
- Add `github` entry to README commands table
- Supports `--aliases` for `rautils load` shell integration (`ra::github::open-actions`)

## Screenshots

N/A (CLI command)

## Pay attention to:

- The command uses macOS `open` — this is consistent with the project being macOS-only
- Structure follows the same grouped pattern as `rautils-git`, ready for future subcommands

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
